### PR TITLE
Fix exception in Blob.split(byte)

### DIFF
--- a/RomUtilities/Blob.cs
+++ b/RomUtilities/Blob.cs
@@ -208,9 +208,17 @@ namespace RomUtilities
 			do
 			{
 				index = Array.IndexOf(copy, separator);
-				segments.Add(copy.SubBlob(0, index));
-				copy = copy.SubBlob(index + 1);
-			} while (index != -1);
+                if (index >= 0)
+                {
+                    segments.Add(copy.SubBlob(0, index));
+                    copy = copy.SubBlob(index + 1);
+                }
+            } while (index != -1);
+
+            if (copy.Length > 0)
+            {
+                segments.Add(copy);
+            }
 
 			return segments;
 		}


### PR DESCRIPTION
Blob.split(byte) would (always?) throw since it would attempt to get a
subBlob from a start index to "-1" for the last chunk. This adds a check
and tacks on the final subblob to the list, if it exists.